### PR TITLE
fix: parsing partial seconds in metadata

### DIFF
--- a/QuARG.py
+++ b/QuARG.py
@@ -21,7 +21,7 @@
 """
 
 
-version='1.0.0'
+version='1.0.1'
 print("QuARG version %s" % version)
 
 #TODO: Need to include MS Gothic.ttf when packaging the scripts 

--- a/reportUtils.py
+++ b/reportUtils.py
@@ -546,11 +546,11 @@ def sortMetaFile(issueDF, threshold):
     
     if len(issueDF) > 0:
         for ind, row in issueDF.iterrows():
-            start = datetime.datetime.strptime(row['starttime'], '%Y-%m-%dT%H:%M:%S').date()
+            start = datetime.datetime.strptime(row['starttime'], '%Y-%m-%dT%H:%M:%S.%f').date()
             if pd.isnull(row['endtime']):
                 end = datetime.datetime.now().date()
             else:
-                end = datetime.datetime.strptime(row['endtime'], '%Y-%m-%dT%H:%M:%S').date()
+                end = datetime.datetime.strptime(row['endtime'], '%Y-%m-%dT%H:%M:%S.%f').date()
                 
             Ndays =  len(pd.period_range(start, end, freq='D'))
             target = row['target'].strip()


### PR DESCRIPTION
Fixes issue with parsing datetimes in metadata-related thresholds.

Also bumps up the version to 1.0.1 internally, to match the actual version.