### PR TITLE
Lk mda link

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,3 +19,14 @@ Beta Version 0.0.2
 - Added popups with a list of all MUSTANG metrics and all defined thresholds in the Examine Issues screen
 - Popup if there is an error retrieving metrics during Find Issues
 - Changed definition of the 'dead' threshold to be dead_channel_gsn=1
+
+Version 1.0.0
+- Initial release
+
+Version 1.0.1
+- Updated metadata date parsing to handle updated IRIS station service millisecond output.
+- Change in formatting of GUI to prevent sizing issue seen in certain screen resolutions.
+
+Version 1.1.0
+- Remove reference to deprecated GOAT tool, replaced with MDA
+- Update to install instructions for Apple M1 and M2 chips. 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,13 @@
-Beta Version 0.0.1
-- created QuARG
+Version 1.1.0
+- Remove reference to deprecated GOAT tool, replaced with MDA
+- Update to install instructions for Apple M1 and M2 chips. 
+
+Version 1.0.1
+- Updated metadata date parsing to handle updated IRIS station service millisecond output.
+- Change in formatting of GUI to prevent sizing issue seen in certain screen resolutions.
+
+Version 1.0.0
+- Initial release
 
 Beta Version 0.0.2
 - Ability to read metrics from a local ISPAQ sqlite database file
@@ -20,13 +28,5 @@ Beta Version 0.0.2
 - Popup if there is an error retrieving metrics during Find Issues
 - Changed definition of the 'dead' threshold to be dead_channel_gsn=1
 
-Version 1.0.0
-- Initial release
-
-Version 1.0.1
-- Updated metadata date parsing to handle updated IRIS station service millisecond output.
-- Change in formatting of GUI to prevent sizing issue seen in certain screen resolutions.
-
-Version 1.1.0
-- Remove reference to deprecated GOAT tool, replaced with MDA
-- Update to install instructions for Apple M1 and M2 chips. 
+Beta Version 0.0.1
+- created QuARG

--- a/QuARG.py
+++ b/QuARG.py
@@ -4013,6 +4013,26 @@ class ExamineIssuesScreen(Screen):
                 startdate +"-"+ enddate
         webbrowser.open(goatURL)
 
+    def see_mda(self):
+        self.get_examine_inputs()
+        mdaURL = "http://ds.iris.edu/mda/"
+
+        if not self.network:
+            self.warning_popup("WARNING: Network code required for MDA")
+            return
+        if self.network:
+            mdaURL = f"{mdaURL}{self.network}"
+            if self.station:
+                mdaURL = f"{mdaURL}/{self.station}"
+                if self.location:
+                    mdaURL = f"{mdaURL}/{self.location}"
+                    if self.channel:
+                        mdaURL = f"{mdaURL}/{self.channel}"
+
+        
+        webbrowser.open(mdaURL)
+
+
     def see_events(self):
         self.get_examine_inputs()
         

--- a/QuARG.py
+++ b/QuARG.py
@@ -21,7 +21,7 @@
 """
 
 
-version='1.0.1'
+version='1.1.0'
 print("QuARG version %s" % version)
 
 #TODO: Need to include MS Gothic.ttf when packaging the scripts 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ conda create --name quarg -c conda-forge --file quarg-conda-install.txt
 conda activate quarg
 ```
 
-Alternate instructions for Apple Silicon M1 Mac:
+Alternate instructions for macOS with Apple M1 or M2 chip:
 ```
 cd quarg
 conda update conda

--- a/quarg.kv
+++ b/quarg.kv
@@ -3048,8 +3048,8 @@
 	    				text: "Noise Modes"
 	    				on_release: root.see_nmt()
 	    			CustomButton:
-	    				text: "GOAT"
-	    				on_release: root.see_goat()
+	    				text: "MDA"
+	    				on_release: root.see_mda()
 	    			CustomButton:
 	    				text: "Events"
 	    				on_release: root.see_events()

--- a/quarg.kv
+++ b/quarg.kv
@@ -3048,11 +3048,11 @@
 	    				text: "Noise Modes"
 	    				on_release: root.see_nmt()
 	    			CustomButton:
-	    				text: "MDA"
-	    				on_release: root.see_mda()
-	    			CustomButton:
 	    				text: "Events"
 	    				on_release: root.see_events()
+					CustomButton:
+	    				text: "MDA"
+	    				on_release: root.see_mda()
 	    			CustomButton:
 	    				text: "Station"
 	    				on_release: root.see_stations()


### PR DESCRIPTION
Replacing the deprecated GOAT link to MDA on the Examine Issues pane. Reordered the buttons slightly to group metadata-related buttons together: MDA and station service. 